### PR TITLE
Add disk integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: bundler
 rvm:
   - 2.0.0
   - 2.1.0
-  - 2.2.3
+  - 2.2.5
 script:
   - bundle exec rake spec
   - bundle exec rake test
@@ -39,12 +39,12 @@ matrix:
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.4.0"
 
-  # Ruby 2.2.3
-  - rvm: 2.2.3
+  # Ruby 2.2.5
+  - rvm: 2.2.5
     env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.2.3
+  - rvm: 2.2.5
     env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.2.3
+  - rvm: 2.2.5
     env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.2.3
+  - rvm: 2.2.5
     env: PUPPET_VERSION="~> 3.4.0"

--- a/manifests/integrations/disk.pp
+++ b/manifests/integrations/disk.pp
@@ -1,0 +1,56 @@
+# Class: datadog_agent::integrations::disk
+#
+# This class will install the necessary config to hook the disk check
+#
+# Parameters:
+#   $use_mount
+#       The use_mount parameter will instruct the check to collect disk
+#       and fs metrics using mount points instead of volumes.
+#       values: yes, no (Boolean, default: no)
+#   $excluded_filesystems
+#       The filesystems you wish to exclude, example: tmpfs, run (string or array)
+#   $excluded_disks
+#       The disks you (optional) wish to exclude, example: /dev/sda (string or array)
+#   $excluded_disk_re
+#       Regular expression (optional) to exclude disks, eg: /dev/sde.*
+#   $excluded_mountpoint_re
+#       Regular expression (optional) to exclude mountpoints, eg: /mnt/somebody-elses-problem.*
+#   $all_partitions
+#       The (optional) all_partitions parameter will instruct the check to
+#       get metrics for all partitions. use_mount should be set to yes (to avoid
+#       collecting empty device names) when using this option.
+#   $tag_by_filesystem
+#       The (optional) tag_by_filesystem parameter will instruct the check to
+#       tag all disks with their filesystem (for ex: filesystem:nfs)
+#       valuse: yes, no (Boolean, default: no)
+#
+# Sample Usage:
+#
+#  class { 'datadog_agent::integrations::disk' :
+#      use_mount            => 'yes',
+#      excluded_filesystems => '/dev/tmpfs',
+#      excluded_disk_re     => '/dev/sd[e-z]*'
+#  }
+class datadog_agent::integrations::disk (
+  $use_mount              = 'no',
+  $excluded_filesystems   = undef,
+  $excluded_disks         = undef,
+  $excluded_disk_re       = undef,
+  $excluded_mountpoint_re = undef,
+  $all_partitions         = undef,
+  $tag_by_filesystem      = undef
+) inherits datadog_agent::params {
+  include datadog_agent
+
+  validate_re($use_mount, '^(no|yes)$', "use_mount should be either 'yes' or 'no'")
+
+  file { "${datadog_agent::params::conf_dir}/disk.yaml":
+    ensure  => file,
+    owner   => $datadog_agent::params::dd_user,
+    group   => $datadog_agent::params::dd_group,
+    mode    => '0600',
+    content => template('datadog_agent/agent-conf.d/disk.yaml.erb'),
+    require => Package[$datadog_agent::params::package_name],
+    notify  => Service[$datadog_agent::params::service_name]
+  }
+}

--- a/manifests/integrations/disk.pp
+++ b/manifests/integrations/disk.pp
@@ -43,6 +43,9 @@ class datadog_agent::integrations::disk (
   include datadog_agent
 
   validate_re($use_mount, '^(no|yes)$', "use_mount should be either 'yes' or 'no'")
+  if $all_partitions {
+    validate_re($all_partitions, '^(no|yes)$', "all_partitions should be either 'yes' or 'no'")
+  }
 
   file { "${datadog_agent::params::conf_dir}/disk.yaml":
     ensure  => file,

--- a/spec/classes/datadog_agent_integrations_disk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_disk_spec.rb
@@ -25,7 +25,7 @@ describe 'datadog_agent::integrations::disk' do
   context 'compile errors for incorrect values' do
     let(:params) {{ use_mount: 'heaps' }}
     it do
-      expect { is_expected.to compile }.to raise_error(/Evaluation Error/)
+      expect { is_expected.to compile }.to raise_error(/error\s+during\s+compilation/)
     end
   end
 

--- a/spec/classes/datadog_agent_integrations_disk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_disk_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'datadog_agent::integrations::disk' do
+  let(:facts) {{
+    operatingsystem: 'Ubuntu',
+  }}
+  let(:conf_dir) { '/etc/dd-agent/conf.d' }
+  let(:dd_user) { 'dd-agent' }
+  let(:dd_group) { 'root' }
+  let(:dd_package) { 'datadog-agent' }
+  let(:dd_service) { 'datadog-agent' }
+  let(:conf_file) { "#{conf_dir}/disk.yaml" }
+
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to  contain_file(conf_file).with_content(
+    %r{\s+use_mount:\s+no$}
+  ).with(
+    owner: dd_user,
+    group: dd_group,
+    mode: '0600',
+  )}
+  it { is_expected.to contain_file(conf_file).that_requires("Package[#{dd_package}]") }
+  it { is_expected.to contain_file(conf_file).that_notifies("Service[#{dd_service}]") }
+
+  context 'compile errors for incorrect values' do
+    let(:params) {{ use_mount: 'heaps' }}
+    it do
+      expect { is_expected.to compile }.to raise_error(/Evaluation Error/)
+    end
+  end
+
+  context 'we handle strings and arrays the same' do
+    let(:params) {{
+      use_mount: 'yes',
+      excluded_filesystems: [ 'tmpfs', 'dev' ],
+      excluded_disks: '/dev/sda1'
+    }}
+    it { is_expected.to contain_file(conf_file).with_content(%r{\s+-\s+tmpfs\n\s+-\s+dev$}) }
+  end
+
+end

--- a/spec/classes/datadog_agent_integrations_disk_spec.rb
+++ b/spec/classes/datadog_agent_integrations_disk_spec.rb
@@ -33,9 +33,30 @@ describe 'datadog_agent::integrations::disk' do
     let(:params) {{
       use_mount: 'yes',
       excluded_filesystems: [ 'tmpfs', 'dev' ],
-      excluded_disks: '/dev/sda1'
+      excluded_disks: '/dev/sda1',
+      excluded_disk_re: '/dev/sdb.*',
+      excluded_mountpoint_re: '/mnt/other.*',
+      all_partitions: 'yes',
+      tag_by_filesystem: 'no'
     }}
-    it { is_expected.to contain_file(conf_file).with_content(%r{\s+-\s+tmpfs\n\s+-\s+dev$}) }
+    let(:yaml_conf) {
+       <<-HEREDOC
+init_config:
+
+instances:
+  - use_mount: yes
+    excluded_filesystems:
+      - tmpfs
+      - dev
+    excluded_disks:
+      - /dev/sda1
+    excluded_disk_re: /dev/sdb.*
+    excluded_mountpoint_re: /mnt/other.*
+    all_partitions: yes
+    tag_by_filesystem: no
+        HEREDOC
+     }
+    it { is_expected.to contain_file(conf_file).with_content(yaml_conf) }
   end
 
 end

--- a/templates/agent-conf.d/disk.yaml.erb
+++ b/templates/agent-conf.d/disk.yaml.erb
@@ -1,7 +1,7 @@
 init_config:
 
 instances:
-  - use_mount: <%= @use_mount -%>
+  - use_mount: <%= @use_mount %>
 <% if @excluded_filesystems -%>
     excluded_filesystems:
 <% (Array(@excluded_filesystems)).each do |fs| -%>
@@ -21,8 +21,8 @@ instances:
     excluded_mountpoint_re: <%= @excluded_mountpoint_re %>
 <% end -%>
 <% if @all_partitions -%>
-    all_partitions: <%= @all_partitions -%>
+    all_partitions: <%= @all_partitions %>
 <% end -%>
 <% if @tag_by_filesystem -%>
-    tag_by_filesystem: <%= @tag_by_filesystem -%>
+    tag_by_filesystem: <%= @tag_by_filesystem %>
 <% end -%>

--- a/templates/agent-conf.d/disk.yaml.erb
+++ b/templates/agent-conf.d/disk.yaml.erb
@@ -1,0 +1,28 @@
+init_config:
+
+instances:
+  - use_mount: <%= @use_mount -%>
+<% if @excluded_filesystems -%>
+    excluded_filesystems:
+<% (Array(@excluded_filesystems)).each do |fs| -%>
+      - <%= fs %>
+<%- end -%>
+<% end -%>
+<% if @excluded_disks -%>
+    excluded_disks:
+<% (Array(@excluded_disks)).each do |disk| -%>
+      - <%= disk %>
+<% end -%>
+<% end -%>
+<% if @excluded_disk_re -%>
+    excluded_disk_re: <%= @excluded_disk_re %>
+<% end -%>
+<% if @excluded_mountpoint_re -%>
+    excluded_mountpoint_re: <%= @excluded_mountpoint_re %>
+<% end -%>
+<% if @all_partitions -%>
+    all_partitions: <%= @all_partitions -%>
+<% end -%>
+<% if @tag_by_filesystem -%>
+    tag_by_filesystem: <%= @tag_by_filesystem -%>
+<% end -%>


### PR DESCRIPTION
DataDog has a disk intergration, this adds `disk.yaml` to the `/etc/dd-agent/conf.d/disk.yaml`

This takes all the options from `disk.yaml.default` file provided by the datadog agent and puppetises them.
